### PR TITLE
fix: support false values

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function toJs(node) {
 function computeProps(props) {
   return props.reduce((acc, prop) => {
     const val = toJs(prop.value)
-    if (val) {
+    if (val !== undefined) {
       return {
         ...acc,
         [prop.key.name]: val

--- a/index.js
+++ b/index.js
@@ -23,9 +23,11 @@ function toJs(node) {
 function computeProps(props) {
   return props.reduce((acc, prop) => {
     const val = toJs(prop.value)
-    return {
-      ...acc,
-      [prop.key.name]: val
+    if (val !== undefined) {
+      return {
+        ...acc,
+        [prop.key.name]: val
+      }
     }
     return acc
   }, {})

--- a/index.js
+++ b/index.js
@@ -23,11 +23,9 @@ function toJs(node) {
 function computeProps(props) {
   return props.reduce((acc, prop) => {
     const val = toJs(prop.value)
-    if (val !== undefined) {
-      return {
-        ...acc,
-        [prop.key.name]: val
-      }
+    return {
+      ...acc,
+      [prop.key.name]: val
     }
     return acc
   }, {})

--- a/tests/sample.js
+++ b/tests/sample.js
@@ -1,5 +1,6 @@
 module.exports = {
   bool: true,
+  false: false,
   str: "my-string",
   obj: {
     isObjectExpression: true,

--- a/tests/sample.js
+++ b/tests/sample.js
@@ -1,6 +1,9 @@
 module.exports = {
   bool: true,
   false: false,
+  undefined: undefined,
+  null: null,
+  num: 8,
   str: "my-string",
   obj: {
     isObjectExpression: true,


### PR DESCRIPTION
Current implementation won't add properties to object if they have a falsy value. This PR checks explicitly for `undefined`.